### PR TITLE
Export 'Get-DomainPolicyData'

### DIFF
--- a/Recon/Recon.psd1
+++ b/Recon/Recon.psd1
@@ -71,6 +71,7 @@ FunctionsToExport = @(
     'Get-DomainGPOUserLocalGroupMapping',
     'Get-DomainGPOComputerLocalGroupMapping',
     'Get-DomainPolicy',
+    'Get-DomainPolicyData',
     'Get-NetLocalGroup',
     'Get-NetLocalGroupMember',
     'Get-NetShare',


### PR DESCRIPTION
Fix issue #363 Get-DomainPolicyData is not recognized when importing PowerSploit.psm1 module